### PR TITLE
add pyproject.toml to support build dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "sshconf"
+version = "0.1.0"
+description = "Lightweight SSH config library"
+authors = [
+    {name = "Søren A D", email = "sorend@acm.org"},
+]
+dependencies = [    ]
+license = {text = "MIT"}
+
+[project.urls]
+homepage = "https://github.com/sorend/sshconf"
+
+[build-system]
+requires = ["pip", "versiontag", "setuptools"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## why I need 
I'm doing a project about manage git ssh keys, and try to use `pdm` as project dependency manager.

however, fail to install sshconf  `pdm add sshconf` see issue here `https://github.com/pdm-project/pdm/issues/860`

It was failed because `pdm` don't know `sshconf` dependent on `pip`.

so, I try to use `pyproject.toml` to specify the install dependency --> pip && setuptools && versiontag

see pypa here `https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/`


## my local test 
I add local repo ssuccessful.

```bash
$ pdm add ../forks/sshconf
Adding packages to default dependencies: sshconf
✔ 🔒 Lock successful
Changes are written to pdm.lock.
Changes are written to pyproject.toml.
Synchronizing working set with lock file: 1 to add, 0 to update, 0 to remove

  ✔ Install sshconf 0.2.3.post4 successful
Installing the project as an editable package...
  ✔ Update git-ssh-key 0.1.0 -> 0.1.0 successful

🎉 All complete!
```

## thanks
thanks for your nice repo again.