### PR TITLE
Feature/add before hosts arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ c.add("newsvu", Hostname="ssh-new.svu.local", Port=22, User="stud1234",
                 RemoteForward=["localhost:2022 localhost:22", "localhost:2025 localhost:25"])
 print("newsvu", c.host("newsvu"))
 
+c.add("oldsvu", before_host="newsvu", Hostname="ssh-old.svu.local", Port=22, User="Stud1234")
+
 c.rename("newsvu", "svu-new")
 print("svu-new", c.host("svu-new"))
 


### PR DESCRIPTION
Resolves issue #16 , by allowing to use parameter `before_host` when `add`ing a new host.

Also `c.hosts()` returns an ordered list, so it can be used to determine which before_host to use, e.g.
```python
c.add('new-host', before_host=c.hosts()[0], Hostname="ssh-new.svu.local", Port=22, User="stud1234")
```